### PR TITLE
Add JSON files for events

### DIFF
--- a/torontojs-json-files/directory/directory.json
+++ b/torontojs-json-files/directory/directory.json
@@ -1,0 +1,102 @@
+[
+  {
+    "title": "UXUI Design Online Talk: Design Systems - A Survival Guide",
+    "url": "https://www.meetup.com/torontojs/events/302199693/?eventOrigin=group_events_list",
+    "startDate": "2024-10-02T18:00:00Z"
+  },
+  {
+    "title": "Code Club Online: Nightmare Before React",
+    "url": "https://www.meetup.com/torontojs/events/303884931/?eventOrigin=group_events_list",
+    "startDate": "2024-10-26T16:00:00Z"
+  },
+  {
+    "title": "TorontoJS [ ONLINE ] TechTalk - CTO Roles and Responsibilities: Ahmad Nassri",
+    "url": "https://www.meetup.com/torontojs/events/303872199/?eventOrigin=group_events_list",
+    "startDate": "2024-10-31T18:30:00Z"
+  },
+  {
+    "title": "Design Talk: Driving Adoption of an Enterprise Design System",
+    "url": "https://www.meetup.com/torontojs/events/302199759/?eventOrigin=group_events_list",
+    "startDate": "2024-11-06T18:00:00Z"
+  },
+  {
+    "title": "Doing the right thing: existential quandaries in software development",
+    "url": "https://www.meetup.com/torontojs/events/304741913/?eventOrigin=group_events_list",
+    "startDate": "2024-12-05T18:30:00Z"
+  }
+]
+
+  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/torontojs-json-files/events/event-2024-10-02.json
+++ b/torontojs-json-files/events/event-2024-10-02.json
@@ -1,0 +1,13 @@
+{
+    "title": "UXUI Design Online Talk: Design Systems - A Survival Guide",
+    "url": "https://www.meetup.com/torontojs/events/302199693/?eventOrigin=group_events_list",
+    "startDate": "2024-10-02T18:00:00Z",
+    "endDate": "2024-10-02T19:00:00Z",
+    "status": "active",
+    "locationType": "virtual",
+    "details": "Join us for a survival guide on design systems in UX/UI design. Learn how to approach design systems and build scalable user interfaces.",
+    "hosts": ["TorontoJS Meetup Group"],
+    "image": "https://example.com/event-image.jpg",
+    "tags": ["UX/UI", "Design Systems", "Online Talk"]
+  } 
+  

--- a/torontojs-json-files/events/event-2024-10-26.json
+++ b/torontojs-json-files/events/event-2024-10-26.json
@@ -1,0 +1,12 @@
+{
+    "title": "Code Club Online: Nightmare Before React",
+    "url": "https://www.meetup.com/torontojs/events/303884931/?eventOrigin=group_events_list",
+    "startDate": "2024-10-26T16:00:00Z",
+    "endDate": "2024-10-26T17:30:00Z",
+    "status": "active",
+    "locationType": "virtual",
+    "details": "In this session, we'll dive into the challenges of React and solve a Nightmare Before React together. Bring your questions!",
+    "hosts": ["TorontoJS Meetup Group"],
+    "image": "https://example.com/event-image.jpg",
+    "tags": ["React", "Code Club", "Online Talk"]
+}

--- a/torontojs-json-files/events/event-2024-10-31.json
+++ b/torontojs-json-files/events/event-2024-10-31.json
@@ -1,0 +1,13 @@
+{
+    "title": "TorontoJS [ ONLINE ] TechTalk - CTO Roles and Responsibilities: Ahmad Nassri",
+    "url": "https://www.meetup.com/torontojs/events/303872199/?eventOrigin=group_events_list",
+    "startDate": "2024-10-31T18:30:00Z",
+    "endDate": "2024-10-31T20:00:00Z",
+    "status": "active",
+    "locationType": "virtual",
+    "details": "Ahmad Nassri will discuss the roles and responsibilities of a CTO, providing insights into how technology leadership drives business success.",
+    "hosts": ["TorontoJS Meetup Group"],
+    "image": "https://example.com/event-image.jpg",
+    "tags": ["CTO", "TechTalk", "Leadership", "Technology"]
+}
+  

--- a/torontojs-json-files/events/event-2024-11-06.json
+++ b/torontojs-json-files/events/event-2024-11-06.json
@@ -1,0 +1,13 @@
+{
+    "title": "Design Talk: Driving Adoption of an Enterprise Design System",
+    "url": "https://www.meetup.com/torontojs/events/302199759/?eventOrigin=group_events_list",
+    "startDate": "2024-11-06T18:00:00Z",
+    "endDate": "2024-11-06T19:30:00Z",
+    "status": "active",
+    "locationType": "virtual",
+    "details": "A talk on the challenges of driving adoption of enterprise design systems and how to integrate them into your workflows.",
+    "hosts": ["TorontoJS Meetup Group"],
+    "image": "https://example.com/event-image.jpg",
+    "tags": ["Design Systems", "Enterprise", "UI/UX", "Adoption"]
+}
+  

--- a/torontojs-json-files/events/event-2024-12-05.json
+++ b/torontojs-json-files/events/event-2024-12-05.json
@@ -1,0 +1,13 @@
+{
+    "title": "Doing the right thing: existential quandaries in software development",
+    "url": "https://www.meetup.com/torontojs/events/304741913/?eventOrigin=group_events_list",
+    "startDate": "2024-12-05T18:30:00Z",
+    "endDate": "2024-12-05T20:00:00Z",
+    "status": "active",
+    "locationType": "virtual",
+    "details": "An exploration of the ethical dilemmas and existential questions that arise in the world of software development.",
+    "hosts": ["TorontoJS Meetup Group"],
+    "image": "https://example.com/event-image.jpg",
+    "tags": ["Software Development", "Ethics", "Existential", "Dilemmas"]
+}
+  


### PR DESCRIPTION
This pull request adds a set of JSON files with event data for different dates, organized under the torontojs-json-files directory, with subfolders for directory and events. These files can be used to test a demo web page or integrated into other projects that need event data. There's no rush to merge them now, but they’re available for later use or testing. 